### PR TITLE
Create a symlink to work around the missing /bin/test

### DIFF
--- a/puppet/app.pp
+++ b/puppet/app.pp
@@ -1,5 +1,10 @@
 Exec { path => "/usr/bin:/usr/sbin:/bin:/sbin" }
 
+# fix dnsmasq, which looks for /bin/test
+file { '/bin/test':
+   ensure => 'link',
+   target => '/usr/bin/test',
+}
 
 stage { 'preinstall':
   before => Stage['main']


### PR DESCRIPTION
Fixes the following error:
    ==> demo: Error: /Stage[main]/Dnsmasq/Exec[reload_resolvconf]: Could not evaluate: /bin/sh: 1: /bin/test: not found
